### PR TITLE
fix: Add truncate to log description

### DIFF
--- a/src/components/pages/dashboard/DashboardLogLevelTag.tsx
+++ b/src/components/pages/dashboard/DashboardLogLevelTag.tsx
@@ -13,7 +13,9 @@ const levels = {
 
 export const DashboardLogLevelTag = ({ level }: OwnProps) => {
   return (
-    <div className={`text-white ${levels[level].color} px-1.5 py-0.25 w-14 rounded text-xs inline-block text-center`}>
+    <div
+      className={`text-white ${levels[level].color} px-1.5 py-0.25 w-14 rounded text-xs inline-block text-center h-full`}
+    >
       {levels[level].name}
     </div>
   );

--- a/src/components/pages/dashboard/DashboardLogRow.tsx
+++ b/src/components/pages/dashboard/DashboardLogRow.tsx
@@ -6,14 +6,17 @@ import { DashboardLogLevelTag } from './DashboardLogLevelTag';
 
 interface OwnProps {
   log: MonitorDataLog;
+  isTruncated?: boolean;
 }
 
-export const DashboardLogRow = ({ log }: OwnProps) => {
+export const DashboardLogRow = ({ log, isTruncated = false }: OwnProps) => {
   return (
-    <div className="space-x-4 mb-1 text-xs whitespace-nowrap">
+    <div className="flex space-x-4 mb-1 text-xs whitespace-nowrap">
       <DashboardLogLevelTag level={log.level} />
-      <span className="text-gray-400">{getFormattedDate(log.date)}</span>
-      <span>{log.description}</span>
+      <div className="text-gray-400">{getFormattedDate(log.date)}</div>
+      <div className={`${isTruncated ? 'max-w-56' : 'max-w-lg'}`}>
+        <div className={`${isTruncated ? 'truncate' : 'whitespace-normal'}`}>{log.description}</div>
+      </div>
     </div>
   );
 };

--- a/src/components/pages/dashboard/DashboardProcessCard.tsx
+++ b/src/components/pages/dashboard/DashboardProcessCard.tsx
@@ -17,7 +17,7 @@ export const DashboardProcessCard = ({ done, proc_start, proc_end }: DashboardPr
   useEffect(() => {
     const elapsedTime = getElapsedTime(proc_start!);
     if (elapsedTime > CONFIG.PROC_START_ALERT_THRESHOLD) setIsAlertOn(true);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="bg-white rounded-lg shadow-md px-5 py-3 w-96">

--- a/src/components/pages/dashboard/DashboardTableRow.tsx
+++ b/src/components/pages/dashboard/DashboardTableRow.tsx
@@ -38,7 +38,7 @@ export const DashboardTableRow = ({ plant, index, onSystemIdClick }: OwnProps) =
         {plant.logs.length > 0 ? (
           <div>
             {plant.logs.slice(0, 5).map((log, index) => (
-              <DashboardLogRow key={index} log={log} />
+              <DashboardLogRow isTruncated key={index} log={log} />
             ))}
 
             {plant.logs.length > 5 ? (

--- a/src/utils/__tests__/viewUtils.spec.ts
+++ b/src/utils/__tests__/viewUtils.spec.ts
@@ -1,4 +1,4 @@
-import { getDistanteToNow, getFormattedDate, getElapsedTime } from 'utils/viewUtils';
+import { getDistanteToNow, getElapsedTime, getFormattedDate } from 'utils/viewUtils';
 
 describe('getIsoToLocalDate', () => {
   it('transforms UTC iso to local time date', () => {


### PR DESCRIPTION
## Description
- [x] Log description is truncated in dashboard table to provide a more stable and consistent layout. 
![image](https://user-images.githubusercontent.com/42070238/111054266-a0b00c00-84ae-11eb-8289-5c828b5c6004.png)

- [x] Log description is wrapped in the dialog screen so users can see the whole description. 
![image](https://user-images.githubusercontent.com/42070238/111054286-c9380600-84ae-11eb-9724-374e6ee53f7e.png)

## Related Issue
Resolves #32
