### PR TITLE
feat: UI minor tweaks

### DIFF
--- a/src/components/EnergySeriesChart.tsx
+++ b/src/components/EnergySeriesChart.tsx
@@ -51,12 +51,31 @@ export const EnergySeriesChart = ({ data }: OwnProps) => {
             },
           },
         ],
-        xAxes: [{ display: false }], //Not displaying x labels to save vertical space.
+        xAxes: [
+          {
+            type: 'time',
+            time: {
+              unit: 'minute',
+              stepSize: 60,
+              displayFormats: {
+                minute: 'h:mm',
+              },
+            },
+            ticks: {
+              fontColor: data.length > 0 ? '#1C1917' : '#F3F4F6', //Hack to hide badly parsed tick values while maintaining height space for ticks. (For the sake of layout stability)
+              maxTicksLimit: 3,
+              maxRotation: 0,
+              minRotation: 0,
+              fontSize: 11,
+              lineHeight: 0.4,
+            },
+          },
+        ],
       },
       legend: { display: false },
       animation: { duration: 0 }, //To improve performance
       responsiveAnimationDuration: 0, //To improve performance
-    };
+    } as Chart.ChartConfiguration;
 
     new Chart(context, { type: 'line', data: { labels, datasets }, options });
   }, [data]);

--- a/src/components/EnergySeriesChart.tsx
+++ b/src/components/EnergySeriesChart.tsx
@@ -58,7 +58,7 @@ export const EnergySeriesChart = ({ data }: OwnProps) => {
               unit: 'minute',
               stepSize: 60,
               displayFormats: {
-                minute: 'h:mm',
+                minute: 'H:mm',
               },
             },
             ticks: {

--- a/src/components/EnergySeriesChart.tsx
+++ b/src/components/EnergySeriesChart.tsx
@@ -42,12 +42,20 @@ export const EnergySeriesChart = ({ data }: OwnProps) => {
       scales: {
         yAxes: [
           {
+            scaleLabel: {
+              display: data.length > 0,
+              labelString: 'Energy (kWh)',
+              fontColor: '#6B7280',
+              fontFamily: ' Arial, Helvetica, sans-serif',
+              fontStyle: 'bold',
+              fontSize: 12,
+            },
             ticks: {
               beginAtZero: true,
               maxTicksLimit: 6, //To avoid having the y axis to crowded with labels.
             },
             afterFit: function (scaleInstance: any) {
-              scaleInstance.width = 60;
+              scaleInstance.width = 80;
             },
           },
         ],

--- a/src/components/pages/dashboard/DashboardTopArea.tsx
+++ b/src/components/pages/dashboard/DashboardTopArea.tsx
@@ -24,7 +24,7 @@ export const DashboardTopArea = (props: OwnProps) => {
           <div className="py-2 pl-12 pr-6 whitespace-nowrap w-56">System ID/Name</div>
           <div className="py-2 px-6 whitespace-nowrap w-52">Last Update Time</div>
           <div className="py-2 px-6 whitespace-nowrap flex-grow">Logs</div>
-          <div className="py-2 pl-6 pr-12 whitespace-nowrap w-128">Energy</div>
+          <div className="py-2 pl-6 pr-12 whitespace-nowrap w-128">Energy (kWh)</div>
         </div>
       </div>
     </div>

--- a/src/utils/__tests__/viewUtils.spec.ts
+++ b/src/utils/__tests__/viewUtils.spec.ts
@@ -1,14 +1,14 @@
 import { getDistanteToNow, getElapsedTime, getFormattedDate } from 'utils/viewUtils';
 
 describe('getIsoToLocalDate', () => {
-  it('transforms UTC iso to local time date', () => {
-    const date = getFormattedDate(`2021-02-22T01:26:31.207`);
-    expect(date).toBe('2021-02-22 10:26:31');
+  it('formats date without applying local time difference', () => {
+    const date = getFormattedDate(`2021-03-23T14:18:00.614`);
+    expect(date).toBe('2021-03-23 14:18:00');
   });
 
   it('parses time without T and miliseconds', () => {
     const date = getFormattedDate(`2021-02-20 00:15:00`);
-    expect(date).toBe('2021-02-20 09:15:00');
+    expect(date).toBe('2021-02-20 00:15:00');
   });
 
   it('returns "Invalid date" string when invalid date format received', () => {
@@ -25,7 +25,7 @@ describe('getIsoToLocalDate', () => {
 describe('getElapsedTime', () => {
   beforeAll(() => {
     jest.useFakeTimers('modern');
-    jest.setSystemTime(new Date('2021-03-02T15:08:00.000Z'));
+    jest.setSystemTime(new Date('2021-03-02T15:08:00.000'));
   });
 
   afterAll(() => {

--- a/src/utils/chartUtils.ts
+++ b/src/utils/chartUtils.ts
@@ -1,7 +1,5 @@
-//TODO: Some method to generate the palette of colors
-//we want for the graph lines.
 export const getChartLineColors = (index: number): string => {
-  const defaultHue = 66;
+  const defaultHue = 130;
   const multiplier = 4;
-  return `hsl(${defaultHue + index * multiplier}deg 82% 55%)`;
+  return `hsl(${defaultHue + index * multiplier}deg 53% 29%)`;
 };

--- a/src/utils/viewUtils.ts
+++ b/src/utils/viewUtils.ts
@@ -1,8 +1,7 @@
-import { addMinutes, format, formatDistanceToNowStrict, isValid, parseISO } from 'date-fns';
+import { format, formatDistanceToNowStrict, isValid, parseISO } from 'date-fns';
 
 const getIsoToLocalDate = (iso: string): Date => {
-  const date = parseISO(iso);
-  return addMinutes(date, -date.getTimezoneOffset());
+  return parseISO(iso);
 };
 
 export const getDistanteToNow = (iso: string): string => {


### PR DESCRIPTION
## Description
Resolves #34
Removed time zone offset logic from date parsing. 
In both development and productiong environments, the backend sends date iso without a Z in the end of the string. That causes that javascript interprets the time zone as local when using the date() object. While in development, the received date seemd to be in UTC, in production it seems to be in GMT+9.

Resolves #35 
Displaying x axes ticks in the indicated format. 
Applying `round:"hour"` also affects the graph line, making it looked very fragmented, so I decided to skip that configuration. Please feel free to play around with these settings in case you want to achieve a different result.
![image](https://user-images.githubusercontent.com/42070238/112179904-6da01200-8c3e-11eb-9087-74ebb39c1439.png)

Resolves #36 
Applied a dark green color for consistency with the site palette. 
Please let me know if a different color would be preferred. 