### PR TITLE
feat: Add last update null value visualization

### DIFF
--- a/src/components/EnergySeriesChart.tsx
+++ b/src/components/EnergySeriesChart.tsx
@@ -55,7 +55,7 @@ export const EnergySeriesChart = ({ data }: OwnProps) => {
               maxTicksLimit: 6, //To avoid having the y axis to crowded with labels.
             },
             afterFit: function (scaleInstance: any) {
-              scaleInstance.width = 80;
+              scaleInstance.width = 60;
             },
           },
         ],

--- a/src/components/Lamp.tsx
+++ b/src/components/Lamp.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 interface OwnProps {
-  type?: 'default' | 'success' | 'warning' | 'error';
+  type?: 'default' | 'success' | 'warning' | 'error' | 'info';
   className?: string;
 }
 
@@ -10,6 +10,7 @@ export const lampColors = {
   success: 'bg-green-500',
   warning: 'bg-yellow-500',
   error: 'bg-red-500',
+  info: 'bg-gray-400',
 };
 
 export const Lamp = ({ type = 'default', className = '' }: OwnProps) => {

--- a/src/components/pages/dashboard/DashboardTableRow.tsx
+++ b/src/components/pages/dashboard/DashboardTableRow.tsx
@@ -29,8 +29,17 @@ export const DashboardTableRow = ({ plant, index, onSystemIdClick }: OwnProps) =
 
       <td className={`${verticalPadding} px-6`}>
         <div className="flex items-center whitespace-nowrap">
-          <Lamp type="success" />
-          {plant.last_update && getDistanteToNow(plant.last_update)}
+          {plant.last_update ? (
+            <>
+              <Lamp type="success" />
+              {plant.last_update && getDistanteToNow(plant.last_update)}
+            </>
+          ) : (
+            <>
+              <Lamp type="info" />
+              <span className="italic text-gray-700">No data</span>
+            </>
+          )}
         </div>
       </td>
 


### PR DESCRIPTION
## Description
Change the color to grey if last_update is `null`, and show text that says "No data". 
![image](https://user-images.githubusercontent.com/42070238/113011343-aa2abb00-91b4-11eb-8f4b-f7d17a221dce.png)


## Related Issue
Resolves #40

## Extra

Issue: Too much space between the y-axis label and the graph.

`Production screencapture`
![image](https://user-images.githubusercontent.com/42070238/113011621-ee1dc000-91b4-11eb-9f1f-b31d6f1a7c3c.png)

Suggested solution: reducing y-axis total width so the space between is reduced. 
Please, feel free to undo this change if you feel it is unnecessary. 
